### PR TITLE
Fixed "RuntimeError: Calling Tcl from different appartment"

### DIFF
--- a/networking/client/gui.py
+++ b/networking/client/gui.py
@@ -112,3 +112,4 @@ lblStatus.pack(side=tkinter.TOP, padx=10, pady=10)
 
 def start():
     top.mainloop()
+    os._exit(0)

--- a/networking/client/gui.py
+++ b/networking/client/gui.py
@@ -110,9 +110,5 @@ lblSuccess.pack(side=tkinter.TOP, padx=10, pady=10)
 lblStatus = tkinter.Label(frmStatus, text='Status: Awaiting connection...', font="Verdana 10 bold")
 lblStatus.pack(side=tkinter.TOP, padx=10, pady=10)
 
-def mainThread():
-    top.mainloop()
-    os._exit(0)
-
 def start():
-    threading.Thread(target=mainThread).start()
+    top.mainloop()

--- a/networking/client/main.py
+++ b/networking/client/main.py
@@ -2,9 +2,9 @@ import os
 
 import server
 import gui
-            
+
 try:
+    server.start()
     gui.start()
-    server.run()
 except KeyboardInterrupt:
     os._exit(0)

--- a/networking/client/server.py
+++ b/networking/client/server.py
@@ -7,6 +7,7 @@ import random
 import util
 import request
 import gui
+import threading
 
 import socket
 import socketserver
@@ -149,6 +150,9 @@ class BGBLinkCableServer(socketserver.BaseRequestHandler):
                     environment.response_sent = False
                     self.dataReceived(conn, environment, p['b'])
 
-def run():
+def serverThread():
     server = socketserver.ThreadingTCPServer(('127.0.0.1', 8765), BGBLinkCableServer)
     server.serve_forever()
+	
+def start():
+    threading.Thread(target=serverThread).start()


### PR DESCRIPTION
On my machine I was getting that error and I fixed it by starting the server in a second thread before loading the gui + having the gui running in the main thread:
```Exception in thread Thread-1:
Traceback (most recent call last):
  File "E:\Python365\lib\threading.py", line 916, in _bootstrap_inner
    self.run()
  File "E:\Python365\lib\threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "D:\Cartelle varie\Programming\github\fools2018-1\networking\client\gui.py", line 114, in mainThread
    top.mainloop()
  File "E:\Python365\lib\tkinter\__init__.py", line 1280, in mainloop
    self.tk.mainloop(n)
RuntimeError: Calling Tcl from different appartment