### PR TITLE
Fixed TypeError in requestHandlerLottery

### DIFF
--- a/networking/server/handlers.py
+++ b/networking/server/handlers.py
@@ -205,12 +205,12 @@ def requestHandlerLottery(request, sessid):
     for i in range(1, match_count+1):
         storage.push_event(user['id'], storage.EVT_LOTTERY, i)
 
-    return b''.join(
+    return b''.join((
         bytes([match_count]),
         letter_str,
         type_str,
         bytes([random.randrange(0, 255)])
-    )
+    ))
 
 '''
     [request_code = 0x08, GAVE_BALLS]

--- a/networking/server/request.py
+++ b/networking/server/request.py
@@ -34,7 +34,7 @@ def handle(request, sessid):
     length_h = content_length // 256
     length_l = content_length % 256
 
-    out = [length_l, length_h, checksum_l, checksum_h, req_code] + req_result
+    out = b''.join((bytes([length_l]), bytes([length_h]), bytes([checksum_l]), bytes([checksum_h]), bytes([req_code]), bytes(req_result)))
     logger.log("RESP: " + binascii.hexlify(bytearray(out)).decode('ascii'))
 
     return out


### PR DESCRIPTION
I was normally playing on my server (everything is unchanged respect to the original version) and when I tried to do a game in the lottery I wasn't able to synchronize my progress, and I was stucked in a loop where I could only retry. Anyway, I checked the logs and this was the error it was poping up: 
```
REQ:  0600a4a507ff
Traceback (most recent call last):
  File "/usr/lib/python3.4/wsgiref/handlers.py", line 137, in run
    self.result = application(self.environ, self.start_response)
  File "/home/bepis/fools2018/networking/server/router.py", line 105, in __call__
    return result.app(environ, start_response)
  File "main.py", line 71, in appBackendRequest
    result = request.handle(data, session_key)
  File "/home/bepis/fools2018/networking/server/request.py", line 31, in handle
    req_result = handlers.HANDLERS[req_code](list(request[5:]), sessid)
  File "/home/bepis/fools2018/networking/server/handlers.py", line 212, in requestHandlerLottery
    bytes([random.randrange(0, 255)])
TypeError: join() takes exactly one argument (4 given)
```
I'm using Python 3.4.2 and this is the command I run for start the server: `bepis@minibian:~/fools2018/networking/server$ /usr/bin/python3 main.py`

I didn't tested yet if really everything is working after this fix. At least map loading and lottery does lmao
I'll come back there in some days and I'll tell you if everything works correctly. 

Oh, probably it's a really bad workaround. Don't blame me, I'm not good in python :c